### PR TITLE
Mark the NOTES formula columns after filling them, not before

### DIFF
--- a/R/metric_values_excel.R
+++ b/R/metric_values_excel.R
@@ -151,8 +151,11 @@ metvalgrpxl <- function(fun.DF.MetVal,
   nrow_NOTES   <- 15
   #NOTES        <- data.frame(matrix(ncol = 3, nrow = nrow_NOTES))
   NOTES        <- data.frame(matrix(ncol = 3))
-  NOTES[, 2] <- writexl::xl_formula('=""') # set column as formula
-  NOTES[, 3] <- writexl::xl_formula('=""') # set column as formula
+  # Columns 2 and 3 hold Excel formulas.  They are marked as such after they
+  # are filled in, just before the write: writexl >= 2.0.0 has xl_formula()
+  # return a cell object rather than a classed character vector, so seeding an
+  # empty column with it and then overwriting rows leaves a plain list column,
+  # which write_xlsx() refuses.
   NOTES[1, 1]  <- "BioMonTools, Metric Values Groups"
   NOTES[3, 1]  <- "Path and FileName"
   NOTES[3, 2]  <- "=LEFT(@CELL(\"filename\",A1),FIND(\"]\",@CELL(\"filename\",A1)))"
@@ -241,6 +244,11 @@ B10))+1,LEN(@CELL(\"filename\",B10))-FIND(\"]\",@CELL(\"filename\",B10)))"
   }## FOR ~ i
 
   # Update NOTES
+  # Mark the formula columns now that every row of them has been assigned.
+  # `[[<-` rather than `[, j] <-`: writexl >= 2.0.0 returns a cell object,
+  # which `[<-.data.frame` treats as many rows rather than one column.
+  NOTES[[2]] <- writexl::xl_formula(NOTES[[2]])
+  NOTES[[3]] <- writexl::xl_formula(NOTES[[3]])
   result[["NOTES"]] <- NOTES
 
   # Save to Excel


### PR DESCRIPTION
Fix #149

metvalgrpxl() seeded columns 2 and 3 of NOTES with xl_formula('=""') to "set column as formula", then overwrote individual rows with the real formulas.

writexl 2.0.0 has xl_formula() return a cell object -- a list of per-cell records -- rather than the classed character vector 1.5.4 returned.  Seeding a one-row column with it warns ("replacement element 1 has 9 rows to replace 1 rows"), drops the class, and leaves a plain list column; the later row assignments then fill that list with bare strings.  write_xlsx() refuses it:

  writexl cannot write column(s) of these types:
  'X2' (column 2): list
  'X3' (column 3): list

Neither seeding line did what its comment said even before the error -- the column carried no formula class by the time the sheet was written.  So they are removed, the rows are assigned as plain strings as they already were, and xl_formula() is applied once to each finished column just before the write.

`[[<-` rather than `[, j] <-`: a cell object is a list, and `[<-.data.frame` reads it as many rows rather than one column.

Checked by running the reported example against both writexl versions: 62 formula cells on the NOTES sheet and the HYPERLINK formulas present under 1.5.4 and 2.0.0 alike.  Dropping the list columns before the write would also have silenced the error, but would have taken the file path, file name, worksheet name and every sheet hyperlink out of the NOTES sheet with them.